### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 # .github/workflows/deploy.yml
 name: Deploy Next.js
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BuddeMax/codescanner/security/code-scanning/1](https://github.com/BuddeMax/codescanner/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (applies to all jobs) to explicitly define the least privileges required. Based on the workflow's steps, it only needs to read the repository contents to check out the code and install dependencies. Therefore, we will set `contents: read` as the permission.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
